### PR TITLE
Some functionality added

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,1 +1,2 @@
 julia v0.3-
+DataStructures

--- a/src/MultiPoly.jl
+++ b/src/MultiPoly.jl
@@ -1,10 +1,12 @@
 module MultiPoly
 
+using DataStructures
+
 export
     MPoly, terms, vars, nvars, generators, generator, monomials, deg,
     PolyUnion, newexps, oldexps,
     harmonicpolynomialdim, laplaceharmonicpol,
-    evaluate, diff, integrate
+    evaluate, evaluate_basis, diff, integrate
 
 import Base: zero, one,
     show, print, length, endof, getindex, setindex!, copy, promote_rule, convert, start, next, done, eltype,

--- a/src/MultiPoly.jl
+++ b/src/MultiPoly.jl
@@ -1,19 +1,20 @@
-module MultiPoly 
+module MultiPoly
 
-export 
+export
     MPoly, terms, vars, nvars, generators, generator, monomials, deg,
     PolyUnion, newexps, oldexps,
     harmonicpolynomialdim, laplaceharmonicpol,
-    evaluate
+    evaluate, diff, integrate
 
 import Base: zero, one,
     show, print, length, endof, getindex, setindex!, copy, promote_rule, convert, start, next, done, eltype,
-    *, /, //, -, +, ==, divrem, conj, rem, real, imag
+    *, /, //, -, +, ==, divrem, conj, rem, real, imag, diff
 
 include("mpoly.jl")
 include("mpolyarithmetic.jl")
 include("mpolyprinting.jl")
 include("polyunion.jl")
 include("mpolyevaluation.jl")
+include("mpolycalculus.jl")
 
 end # module

--- a/src/mpoly.jl
+++ b/src/mpoly.jl
@@ -1,5 +1,5 @@
 immutable MPoly{T}
-    terms::Dict{Vector{Int},T}
+    terms::OrderedDict{Vector{Int},T}
     vars::Vector{Symbol}
 end
 
@@ -11,19 +11,19 @@ vars(p::MPoly) = p.vars
 
 nvars(p::MPoly) = length(vars(p))
 
-zero{T}(::Type{MPoly{T}}; vars::Vector{Symbol}=Symbol[]) = MPoly{T}(Dict{Vector{Int},T}(), vars)
+zero{T}(::Type{MPoly{T}}; vars::Vector{Symbol}=Symbol[]) = MPoly{T}(OrderedDict{Vector{Int},T}(), vars)
 zero{T}(p::MPoly{T}) = zero(MPoly{T}, vars=vars(p))
 
-one{T}(::Type{MPoly{T}}; vars::Vector{Symbol}=Symbol[]) = MPoly{T}([zeros(Int, length(vars)) => one(T)], vars)
+one{T}(::Type{MPoly{T}}; vars::Vector{Symbol}=Symbol[]) = MPoly{T}(OrderedDict(zeros(Int, length(vars)) => one(T)), vars)
 one{T}(p::MPoly{T}) = one(MPoly{T}, vars=vars(p))
 
 function generators{T}(::Type{MPoly{T}}, vars::Symbol...)
      m = eye(Int, length(vars))
-     [MPoly{T}([m[:,i] => one(T)], [vars...]) for i = 1:length(vars)]
+     [MPoly{T}(OrderedDict(m[:,i] => one(T)), [vars...]) for i = 1:length(vars)]
 end
 
 generator{T}(::Type{MPoly{T}}, var::Symbol) =
-     MPoly{T}([[1] => one(T)], [var])
+     MPoly{T}(OrderedDict([1] => one(T)), [var])
 
 promote_rule{T,U}(::Type{MPoly{T}}, ::Type{MPoly{U}}) = MPoly{promote_type(T, U)}
 promote_rule{T,U}(::Type{MPoly{T}}, ::Type{U}) = MPoly{promote_type(T, U)}
@@ -36,12 +36,12 @@ function convert{T}(P::Type{MPoly{T}}, p::MPoly)
     r
 end
 
-convert{T}(::Type{MPoly{T}}, c::T) = 
-    MPoly{T}([Int[] => c]) 
+convert{T}(::Type{MPoly{T}}, c::T) =
+    MPoly{T}(OrderedDict(Int[] => c))
 
 monomials(p::MPoly) = keys(terms(p))
 
-getindex{T}(p::MPoly{T}, m::Vector{Int}) = 
+getindex{T}(p::MPoly{T}, m::Vector{Int}) =
     get(terms(p), m, zero(T))
 
 getindex(p::MPoly, m::Int...) = p[[m...]]
@@ -56,7 +56,7 @@ function setindex!{T}(p::MPoly{T}, v, m::Int...)
 end
 
 setindex!{T}(p::MPoly{T}, v, m::Vector{Int}) = p[m...] = v
-    
+
 start(p::MPoly) = start(terms(p))
 next(p::MPoly, state) = next(terms(p), state)
 done(p::MPoly, state) = done(terms(p), state)

--- a/src/mpolycalculus.jl
+++ b/src/mpolycalculus.jl
@@ -1,0 +1,36 @@
+function diff{T}(p::MPoly{T}, symbol::Symbol, n::Int=1)
+    if !(symbol in vars(p))
+        # Should we just return zero(p) here?
+        throw(UndefVarError(:symbol))
+    end
+
+    dp = zero(p)
+    idx = find(vars(p) .== symbol)[1]
+
+    for (m, c) in p
+        if m[idx] - n < 0
+            continue
+        end
+        m2 = copy(m)
+        m2[idx] = m[idx] - n
+        dp[m2] = p[m] * factorial(m[idx], m[idx] - n)
+    end
+    return dp
+end
+
+function integrate{T}(p::MPoly{T}, symbol::Symbol, n::Int=1)
+    if !(symbol in vars(p))
+        # Should we just return something like p * symbol here?
+        throw(UndefVarError(:symbol))
+    end
+    dp = zero(p)
+    idx = find(vars(p) .== symbol)[1]
+
+    for (m, c) in p
+        m2 = copy(m)
+        m2[idx] = m[idx] + n
+        dp[m2] = p[m] * 1/(factorial(m[idx] + n, m[idx]))
+    end
+    return dp
+end
+

--- a/src/mpolyevaluation.jl
+++ b/src/mpolyevaluation.jl
@@ -9,3 +9,15 @@ function evaluate{T}(p::MPoly{T}, es...)
     end
     r
 end
+
+function evaluate_basis{T}(p::MPoly{T}, es...)
+    r = Array(T, 0)
+    for (m, c) in p
+        r1 = c
+        for i = 1:length(m)
+            r1 *= es[i]^m[i]
+        end
+        push!(r, r1)
+    end
+    r
+end

--- a/src/mpolyevaluation.jl
+++ b/src/mpolyevaluation.jl
@@ -1,7 +1,7 @@
 function evaluate{T}(p::MPoly{T}, es...)
-    r = zero(MPoly{T})
+    r = zero(T)
     for (m, c) in p
-        t = c * one(MPoly{T})
+        t = c
         for i = 1:length(m)
             t *= es[i]^m[i]
         end

--- a/test/mpolycalculus.jl
+++ b/test/mpolycalculus.jl
@@ -1,0 +1,20 @@
+x, y = generators(MPoly{Float64}, :x, :y)
+
+p = 4.0 + x^3 + 3.0*x*y^2 + y^3
+@test diff(p, :x, 1) == 3.0x^2 + 3.0y^2
+@test diff(p, :x, 2) == 6.0x
+@test diff(p, :x, 3) == 6.0 * one(p)
+@test diff(p, :y, 1) == 6x*y + 3y^2
+@test_throws UndefVarError diff(p, :z)
+@test p == 4.0 + x^3 + 3*x*y^2 + y^3 # Check p is left alone
+
+p2 = x
+@test diff(p2, :x, 1) == 1.0 * one(p)
+@test diff(p2, :y, 1) == zero(p)
+
+
+p1 = 3.0 + 3x + y^2
+@test integrate(p1, :x, 1) == 3.0x + 3*x^2 * 0.5 + x*y^2
+@test integrate(p1, :y, 2) == 1.5*y^2 + 1.5x*y^2 + (1/3 * 1/4) * y^4
+@test_throws UndefVarError integrate(p, :z)
+@test p1 == 3.0 + 3x + y^2 # Check p is left alone

--- a/test/mpolyevaluation.jl
+++ b/test/mpolyevaluation.jl
@@ -1,0 +1,10 @@
+x, y = generators(MPoly{Float64}, :x, :y)
+
+p = (x+y)^2
+@test_approx_eq evaluate(p, 1, 2) 3^2
+@test evaluate_basis(p, 1, 2) == [1.0, 4.0, 4.0]
+
+p = (x+2y)^3
+@test_approx_eq evaluate(p, 0, 2) 2^3
+@test evaluate_basis(p, 0, 2) == [1.0, 4.0, 4.0]
+

--- a/test/mpolyprinting.jl
+++ b/test/mpolyprinting.jl
@@ -1,3 +1,3 @@
 x, y = generators(MPoly{Float64}, :x, :y)
 
-@test string((x+y)^3) == "3.0x^2*y + x^3 + 3.0x*y^2 + y^3"
+@test string((x+y)^3) == "x^3 + 3.0x^2*y + 3.0x*y^2 + y^3"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using Base.Test
-using MultiPoly 
+using MultiPoly
 
+include("mpolycalculus.jl")
 include("mpoly.jl")
 include("mpolyarithmetic.jl")
 include("mpolyprinting.jl")


### PR DESCRIPTION
Very nice package. I really needed something like this and I started writing my own but then I found yours  so it saved me a lot of time.

There was some stuff missing that I needed so I added them and created a PR in case you find them useful. Please comment if there is any parts you don't like.

In summary, this PR makes the following changes.
- Adds a differentiate function with the following syntax: `diff(p, :x, n=1)` This returns a new MultiPoly
  differentiated w.r.t `:x`, `n` times.
- Adds an integrate function that gives the primitive function of the polynomial with the syntax `integrate(p, :x, n=1)`.
- Changed from a normal dictionary to an ordered dictionary. 
  
  Before
  
  ``` julia
  julia> (x+y)^2
  MultiPoly.MPoly{Float64}(x^2 + 2.0x*y + y^2)
  
  julia> (x+y)^3
  MultiPoly.MPoly{Float64}(x^3 + y^3 + 3.0x^2*y + 3.0x*y^2)
  
  julia> (x+y)^4
  MultiPoly.MPoly{Float64}(y^4 + 4.0x^3*y + 6.0x^2*y^2 + 4.0x*y^3 + x^4)
  ```
  
  After:
  
  ``` julia
  julia> (x+y)^2
  MultiPoly.MPoly{Float64}(x^2 + 2.0x*y + y^2)
  
  julia> (x+y)^3
  MultiPoly.MPoly{Float64}(x^3 + 3.0x^2*y + 3.0x*y^2 + y^3)
  
  julia> (x+y)^4
  MultiPoly.MPoly{Float64}(x^4 + 4.0x^3*y + 6.0x^2*y^2 + 4.0x*y^3 + y^4)
  ```
- Makes evaluate return a number instead of a `MPoly`
- Add an `evaluate_basis` function (not sure about this name) has the same syntax as `evaluate` but instead returns a list of the contribution of all the terms in the polynomial.
- Add tests for everything
