### PR TITLE
Updates to support julia 0.4 and 0.5 nightlies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,17 +1,16 @@
-language: cpp
-compiler:
-  - clang
+# Documentation: http://docs.travis-ci.com/user/languages/julia/
+language: julia
+os:
+  - linux
+  - osx
+julia:
+  - release
+  - nightly
 notifications:
   email: false
-env:
-  matrix: 
-    - JULIAVERSION="juliareleases" 
-    - JULIAVERSION="julianightlies" 
-before_install:
-  - sudo add-apt-repository ppa:staticfloat/julia-deps -y
-  - sudo add-apt-repository ppa:staticfloat/${JULIAVERSION} -y
-  - sudo apt-get update -qq -y
-  - sudo apt-get install libpcre3-dev julia -y
-script:
-  - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir("MultiPoly"))`); Pkg.pin("MultiPoly"); Pkg.resolve()'
-  - julia -e 'using MultiPoly; @assert isdefined(:MultiPoly); @assert typeof(MultiPoly) === Module'
+
+
+# uncomment the following lines to override the default test script
+#script:
+#  - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
+#  - julia -e 'Pkg.clone(pwd()); Pkg.build("Mayday"); Pkg.test("Mayday"; coverage=true)'

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,3 @@
 julia v0.3-
 DataStructures
+Combinatorics

--- a/src/MultiPoly.jl
+++ b/src/MultiPoly.jl
@@ -11,7 +11,7 @@ export
 
 import Base: zero, one,
     show, showcompact, print, length, endof, getindex, setindex!, copy, promote_rule, convert, start, next, done, eltype,
-    *, /, //, -, +, ==, divrem, conj, rem, real, imag, diff
+    *, /, //, -, +, ==, ^, divrem, conj, rem, real, imag, diff
 
 include("mpoly.jl")
 include("mpolyarithmetic.jl")

--- a/src/MultiPoly.jl
+++ b/src/MultiPoly.jl
@@ -1,6 +1,7 @@
 module MultiPoly
 
 using DataStructures
+using Combinatorics
 
 export
     MPoly, terms, vars, nvars, generators, generator, monomials, deg,


### PR DESCRIPTION
This includes a few very minor modifications to handle changes that have come in with the last two minor Julia versions:
- explicitly imports ^ from Base to silence a warning
- uses the `Combinatorics` package to provide `factorial`, which is necessary on the 0.5 nightlies
- switches to Travis-CI's built-in Julia support for automatic testing with release and nightly versions: https://travis-ci.org/rdeits/MultiPoly.jl/jobs/106874824
