### PR TITLE
more efficient variable index lookup

### DIFF
--- a/src/mpolycalculus.jl
+++ b/src/mpolycalculus.jl
@@ -1,10 +1,16 @@
 function diff{T}(p::MPoly{T}, symbol::Symbol, n::Int=1)
-    if !(symbol in vars(p))
+    idx = 0
+    for (i, var) in enumerate(vars(p))
+        if var == symbol
+            idx = i
+            break
+        end
+    end
+    if idx == 0 # symbol was not found
         return zero(p)
     end
 
     dp = zero(p)
-    idx = find(vars(p) .== symbol)[1]
 
     for (m, c) in p
         if m[idx] - n < 0


### PR DESCRIPTION
Significantly speeds up variable index lookup in diff().

I noticed that line 7 of diff() was consuming almost half of the time of the entire function call, so I've rewritten it to remove unnecessary allocations and function calls. Previously, the code was allocating an array for `vars(p) .== symbol`, allocating another array for `find()`, and then indexing the result. Now the search loop is explicit, and also handles the `symbol in vars(p)` check at the same time. 
