### PR TITLE
prevent unnecessary conversions

### DIFF
--- a/src/mpoly.jl
+++ b/src/mpoly.jl
@@ -25,14 +25,18 @@ end
 generator{T}(::Type{MPoly{T}}, var::Symbol) =
      MPoly{T}(OrderedDict([1] => one(T)), [var])
 
-call{T}(::Type{MPoly{T}}, var::Symbol) = 
+call{T}(::Type{MPoly{T}}, var::Symbol) =
      MPoly{T}(OrderedDict([1] => one(T)), [var])
 
-call(::Type{MPoly}, var::Symbol) = 
+call(::Type{MPoly}, var::Symbol) =
      MPoly{Float64}(var)
 
 promote_rule{T,U}(::Type{MPoly{T}}, ::Type{MPoly{U}}) = MPoly{promote_type(T, U)}
 promote_rule{T,U}(::Type{MPoly{T}}, ::Type{U}) = MPoly{promote_type(T, U)}
+
+function convert{T}(P::Type{MPoly{T}}, p::MPoly{T})
+    p
+end
 
 function convert{T}(P::Type{MPoly{T}}, p::MPoly)
     r = zero(P, vars=vars(p))


### PR DESCRIPTION
While profiling, I noticed frequent unnecessary calls to `convert()` for `MPoly`, for which the input and output types were exactly the same. I'm still not entirely sure whey this was happening, so this may not be the right fix, but this defines a no-op convert() function when the input and output types match exactly. 

Note that this does change the behavior slightly: previously, calling `convert(MPoly{T}, p::MPoly{T})` would copy the polynomial and call `convert(T, c::T)` on each coefficient. Now the conversion and copy only happen if the input and output types are actually different. 

Do you have any insight into why `convert()` is being called so often? And does this seem like the right fix? 
